### PR TITLE
`Dockerfile` のベースイメージを更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.9.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.10.2
 RUN elasticsearch-plugin install analysis-kuromoji
 RUN elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
## 変更点
- `Dockerfile` のベースイメージを更新
    -  ElasticSearchの `v7.10.2` を使うように変更